### PR TITLE
Add Collection model tests and supporting factories

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,7 +11,7 @@ MedusaCollectionRegistry::Application.configure do
 
   # configure mailer
   config.action_mailer.perform_caching = false
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = :test
 
   config.action_mailer.smtp_settings = {
     address: settings["smtp"]["smtp_settings"]["address"],
@@ -59,6 +59,8 @@ MedusaCollectionRegistry::Application.configure do
 
   config.middleware.use RackSessionAccess::Middleware
 
-  #config.assets.compile = false
-
+  #disable asset compilation during tests
+  # config.assets.compile = false
+  # config.assets.debug = false
+  # config.assets.quiet = true
 end

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -1,0 +1,17 @@
+# spec/factories/assessments.rb
+FactoryBot.define do
+  factory :assessment do
+    sequence(:name) { |n| "Assessment #{n}" }
+    assessable { nil }
+    assessment_type { Assessment.assessment_types.first }
+    preservation_risk_level { Assessment.risk_levels.first }
+
+    trait :for_collection do
+      association :assessable, factory: :collection
+    end
+
+    trait :for_file_group do
+      association :assessable, factory: :file_group
+    end
+  end
+end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -3,7 +3,36 @@ FactoryBot.define do
   factory :collection do
     sequence(:title) { |n| "Collection #{n}" }
     publish { true }
-    description { "Test description for collection" }
+    description { "Test collection" }
     repository
+    #association :contact, factory: :person
+
+    # Ensure rights_declaration is only created if not already provided
+    after(:build) do |collection, evaluator|
+      # Use the repository passed into the factory if present
+      collection.parent ||= collection.repository
+      if collection.respond_to?(:rights_declaration) && collection.rights_declaration.nil?
+        collection.rights_declaration = build(:rights_declaration, declarable: collection)
+      end
+    end
+
+    trait :with_bit_level_file_groups do
+      after(:create) do |collection|
+        create_list(:bit_level_file_group, 2, collection: collection)
+      end
+    end
+
+    trait :with_assessments do
+      after(:create) do |collection|
+        create_list(:assessment, 2, assessable: collection)
+      end
+    end
+
+    trait :with_file_group_assessments do
+      after(:create) do |collection|
+        file_group = create(:file_group, collection: collection)
+        create(:assessment, assessable: file_group)
+      end
+    end
   end
 end

--- a/spec/factories/file_groups.rb
+++ b/spec/factories/file_groups.rb
@@ -1,13 +1,15 @@
+# spec/factories/file_groups.rb
 FactoryBot.define do
   factory :file_group do
     title { "Test File Group" }
-    description { "A description of the file group." }
-    collection { create(:collection, repository: create(:repository)) }
+    description { "File group description" }
+    association :collection
     producer { create(:producer) }
     total_files { 0 }
-    total_file_size { 0 }
+    total_file_size { nil } 
   end
 
-  factory :bit_level_file_group, parent: :file_group, class: 'BitLevelFileGroup' do
+  factory :bit_level_file_group, parent: :file_group, class: BitLevelFileGroup do
+    type { 'BitLevelFileGroup' }
   end
 end

--- a/spec/factories/rights_declarations.rb
+++ b/spec/factories/rights_declarations.rb
@@ -1,0 +1,19 @@
+# spec/factories/rights_declarations.rb
+FactoryBot.define do
+  factory :rights_declaration do
+    rights_basis { "copyright" } 
+    copyright_jurisdiction { "us" }
+    copyright_statement { "pd" } 
+    access_restrictions { "DISSEMINATE" } 
+
+    
+    #declarable transient attribute link declaration to a collection
+    transient do
+      declarable { nil }
+    end
+
+    after(:build) do |rights_declaration, evaluator|
+      rights_declaration.rights_declarable = evaluator.declarable if evaluator.declarable
+    end
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+RSpec.describe Collection, type: :model do
+  
+  describe 'associations' do
+    it { should belong_to(:repository) }
+    it { should have_many(:assessments).dependent(:destroy) }
+    it { should have_many(:file_groups).dependent(:destroy) }
+    it { should have_one(:rights_declaration).dependent(:destroy) }
+    it { should have_many(:attachments).dependent(:destroy) }
+    it { should have_many(:projects) }
+    it { should have_many(:child_collections) }
+    it { should have_many(:parent_collections) }
+  end
+
+  describe 'validations' do 
+    subject { build(:collection, repository: create(:repository)) }
+    it 'is valid with valid attributes' do 
+      expect(subject).to be_valid
+    end
+    
+    it 'is invalid without a title' do
+      subject.title = nil
+      expect(subject).not_to be_valid
+      expect(subject.errors[:title]).to include("can't be blank")
+    end
+
+    it 'is invalid without a repository' do
+      subject.repository = nil
+      expect(subject).not_to be_valid
+      expect(subject.errors[:repository_id]).to include("can't be blank")
+    end
+
+    it 'is invalid with a duplicate title in the same repository' do
+      create(:collection, title: subject.title, repository: subject.repository)
+      expect(subject).not_to be_valid
+      expect(subject.errors[:title]).to include("has already been taken")
+    end
+
+    it 'is valid with a duplicate title in a different repository' do
+      other_repo = create(:repository)
+      create(:collection, title: "Shared Title", repository: other_repo)
+
+      subject.title = "Shared Title"
+      subject.repository = create(:repository) 
+      expect(subject).to be_valid
+    end
+  end
+
+  describe 'callbacks' do 
+    it 'ensures a rights declaration if none exists' do 
+      collection = build(:collection, rights_declaration: nil)
+      collection.valid?
+      expect(collection.rights_declaration).to be_present
+    end
+  end
+
+  describe 'scopes and class methods' do
+    describe '.title_order' do
+      it 'returns collections ordered by title ASC' do
+        c1 = create(:collection, title: 'Zoo')
+        c2 = create(:collection, title: 'Alpha')
+        expect(Collection.title_order).to eq([c2, c1])
+      end
+    end
+  end
+
+  describe 'instance methods' do 
+    it 'calculates total size of bit-level file groups' do 
+      collection = create(:collection)
+      file_group_1 = create(:bit_level_file_group, collection: collection)
+      file_group_2 = create(:bit_level_file_group, collection: collection)
+
+      file_group_1.update!(total_file_size: 100.0)
+      file_group_2.update!(total_file_size: 200.0)
+      
+      expect(collection.total_size).to eq(300.0)
+    end
+
+    it 'sums total_files across bit-level file groups' do
+      collection = create(:collection)
+      create(:bit_level_file_group, collection: collection).update_column(:total_files, 5)
+      create(:bit_level_file_group, collection: collection).update_column(:total_files, 7)
+
+      expect(collection.total_files).to eq(12)
+    end
+    
+    it 'returns both direct assessments and file group assessments' do
+      collection = create(:collection)
+      file_group = create(:bit_level_file_group, collection: collection)
+
+      assessment1 = create(:assessment, assessable: collection)
+      assessment2 = create(:assessment, assessable: file_group)
+
+      expect(collection.recursive_assessments).to contain_exactly(assessment1, assessment2)
+    end
+
+    it 'returns IDs from non-empty CFS directories of bit-level file groups' do
+      collection = create(:collection)
+      file_group = create(:bit_level_file_group, collection: collection)
+      #stub cfs directory as non empty and return sub directory Ids [101, 102]
+      cfs_directory = instance_double('CfsDirectory', is_empty?: false, recursive_subdirectory_ids: [101, 102])
+      allow_any_instance_of(BitLevelFileGroup).to receive(:cfs_directory).and_return(cfs_directory)
+
+      expect(collection.timeline_directory_ids).to eq([101, 102])
+    end
+
+    it 'returns a valid HTTPS URL for the collection' do
+      collection = create(:collection)
+      expect(collection.medusa_url).to eq("https://medusa.library.illinois.edu/collections/#{collection.id}")
+    end
+  end
+end


### PR DESCRIPTION
### PR Summary

Added RSpec tests for the `Collection` model and added coverage for validations, associations and key instance methods.

Created new factories for 

`collection`
`assessment`
`rights_declaration`
`file_group`