### PR TITLE
Add aarch64-linux platform to Gemfile.lock for Rocky deployment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1928,6 +1928,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-darwin-23

--- a/config/deploy/demo.rb
+++ b/config/deploy/demo.rb
@@ -16,13 +16,14 @@
 # used to set extended properties on the server.
 #set :home, '/services/medusa'
 set :rails_env, 'demo'
+set :branch, 'main'
 set :home, '/home/medusa'
 set :deploy_to, "#{fetch(:home)}/medusa-cr-capistrano"
 set :bin, "#{fetch(:home)}/bin"
 set :ssh_options, {
     forward_agent: true,
     auth_methods: ["publickey"],
-    keys: ["~/.ssh/medusa_prod.pem"]
+    keys: [File.expand_path("~/.ssh/medusa-2023.pem")]
 }
 
 # Default value for :linked_files is []
@@ -33,7 +34,7 @@ set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', '
                                                'public/system', 'tmp/item_upload_csv', 'public/packs', 'node_modules')
 
 #server 'medusa.library.illinois.edu', user: 'medusa', roles: %w{web app db}, primary: true
-server 'aws-medusa-demo.library.illinois.edu', user: 'medusa', roles: %w{web app db}, primary: true
+server 'medusa-demo-rocky.library.illinois.edu', user: 'medusa', roles: %w{web app db}, primary: true
        # :ssh_options => {
        #     :keepalive => true,
        #     :keepalive_interval => 30 #seconds


### PR DESCRIPTION
This PR adds the `aarch64-linux` platform to the `Gemfile.lock` to support future deployments to the Rocky Linux based server.

Update: Also Added Capistrano demo deployment config for Rocky Linux. This includes setting the main branch and SSH key path. This is required because the Rocky Linux demo server needs the platform update (aarch64-linux) in Gemfile.lock for bundle install to succeed during capistrano deployment.