### PR TITLE
Add public description to repositories

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -155,7 +155,7 @@ class RepositoriesController < ApplicationController
   end
 
   def allowed_params
-    params[:repository].permit(:notes, :title, :url, :address_1, :address_2, :city, :state,
+    params[:repository].permit(:notes, :public_description, :title, :url, :address_1, :address_2, :city, :state,
                                :zip, :phone_number, :email, :active_start_date,
                                :active_end_date, :contact_email, :institution_id)
   end

--- a/app/views/repositories/_form_right.html.haml
+++ b/app/views/repositories/_form_right.html.haml
@@ -4,4 +4,5 @@
 = f.input :url, label: 'URL', type: :url, wrapper: :wide_horizontal_file_input
 = f.input :active_start_date, as: :string, input_html: {class: 'datepicker'}, label: 'Active Start Date', wrapper: :wide_horizontal_file_input
 = f.input :active_end_date, as: :string, input_html: {class: 'datepicker'}, label: 'Active End Date', wrapper: :wide_horizontal_file_input
+= f.input :public_description, as: :text, label: 'Public Description', input_html: { rows: 3 }, wrapper: :wide_horizontal_file_input
 = f.input :notes, input_html: { rows: 3 }, wrapper: :wide_horizontal_file_input

--- a/app/views/repositories/_show_metadata.html.haml
+++ b/app/views/repositories/_show_metadata.html.haml
@@ -4,6 +4,7 @@
     = show_field @repository, :contact_email
     = render partial: 'shared/contact_information', locals: {contact_object: @repository}
     = show_value link_to_external(@repository.url, @repository.url), 'URL'
+    = show_field @repository, :public_description, 'Public Description'
     = show_field @repository, :notes_html, 'Notes'
     = show_value @repository.total_size.to_fs(:rounded, precision: 2), 'Total Size (GB)'
     = show_field @repository, :active_start_date, 'Active Start Date'

--- a/db/migrate/20260609210603_add_public_description_to_repositories.rb
+++ b/db/migrate/20260609210603_add_public_description_to_repositories.rb
@@ -1,0 +1,5 @@
+class AddPublicDescriptionToRepositories < ActiveRecord::Migration[7.0]
+  def change
+    add_column :repositories, :public_description, :text
+  end
+end

--- a/docker-entrypoint-test.sh
+++ b/docker-entrypoint-test.sh
@@ -22,6 +22,7 @@ RAILS_ENV=test bundle exec rails db:environment:set RAILS_ENV=test
 # Prepare the test database
 echo "Preparing the test database..."
 RAILS_ENV=test bundle exec rails db:drop db:create db:schema:load
+RAILS_ENV=test bundle exec rails db:migrate
 
 # Execute the provided command
 exec "$@"


### PR DESCRIPTION
Adds a new Public Description field to Repository records.

* Adds a `public_description` text column to `repositories`
* Permits `public_description` in repository params
* Adds the Public Description text area to the repository edit form
* Displays Public Description in the repository metadata section
* Adds a fix to the `docker-entrypoint-test.sh` file to run new migrations in the test environment

